### PR TITLE
Ensure non-blocking mypy compatibility

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -101,6 +101,15 @@ def typing(session):
     session.run("pyright", *session.posargs, REFERENCING)
 
 
+@session()
+def mypy(session):
+    """
+    Check that mypy runs with no blocking errors.
+    """
+    session.install("mypy", ROOT)
+    session.run("mypy", REFERENCING)
+
+
 @session(tags=["docs"])
 @nox.parametrize(
     "builder",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,10 @@ include_trailing_comma = true
 multi_line_output = 3
 use_parentheses = true
 
+[tool.mypy]
+follow_imports = "skip"
+ignore_errors = true
+
 [tool.pyright]
 reportUnnecessaryTypeIgnoreComment = true
 strict = ["**/*"]

--- a/referencing/jsonschema.py
+++ b/referencing/jsonschema.py
@@ -432,7 +432,7 @@ DRAFT201909 = Specification(
             "properties",
         },
     ),
-    anchors_in=_anchor_2019,  # type: ignore[reportGeneralTypeIssues]  TODO: check whether this is real
+    anchors_in=_anchor_2019,  # type: ignore[reportGeneralTypeIssues]  # TODO: check whether this is real
     maybe_in_subresource=_maybe_in_subresource_crazy_items(
         in_value={
             "additionalItems",
@@ -474,7 +474,7 @@ DRAFT7 = Specification(
         in_subarray={"allOf", "anyOf", "oneOf"},
         in_subvalues={"definitions", "patternProperties", "properties"},
     ),
-    anchors_in=_legacy_anchor_in_dollar_id,  # type: ignore[reportGeneralTypeIssues]  TODO: check whether this is real
+    anchors_in=_legacy_anchor_in_dollar_id,  # type: ignore[reportGeneralTypeIssues]  # TODO: check whether this is real
     maybe_in_subresource=_maybe_in_subresource_crazy_items_dependencies(
         in_value={
             "additionalItems",
@@ -505,7 +505,7 @@ DRAFT6 = Specification(
         in_subarray={"allOf", "anyOf", "oneOf"},
         in_subvalues={"definitions", "patternProperties", "properties"},
     ),
-    anchors_in=_legacy_anchor_in_dollar_id,  # type: ignore[reportGeneralTypeIssues]  TODO: check whether this is real
+    anchors_in=_legacy_anchor_in_dollar_id,  # type: ignore[reportGeneralTypeIssues]  # TODO: check whether this is real
     maybe_in_subresource=_maybe_in_subresource_crazy_items_dependencies(
         in_value={
             "additionalItems",


### PR DESCRIPTION
`mypy` follows imports to third-party dependency packages by default. If the package has any blocking errors, `mypy` cannot perform any type checking.
This PR ensures that `referencing` is compatible with the latest version of `mypy` and will not produce any fatal blocking errors.
These checks are added to CI through `nox`. Type checks within `referencing` are still done with `pyright`.

This also fixes an invalid `type: ignore` syntax issue (#128), where non-PEP484 syntax caused a blocking error in `mypy<0.990`.