### PR TITLE
Add lower bound pin for typing-extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = ["version"]
 dependencies = [
   "attrs>=22.2.0",
   "rpds-py>=0.7.0",
-  "typing-extensions; python_version<'3.13'",
+  "typing-extensions>=4.4.0; python_version<'3.13'",
 ]
 
 [project.urls]


### PR DESCRIPTION
The changes in https://github.com/python-jsonschema/referencing/commit/5ea5a1539378f80caa9d6969849ee61667cb7252 broke one of our CI pipelines today with the release of referencing 0.36.0. The reason is that the `default` parameter for `TypeVar` only exists in `typing-extensions>=4.4.0`. This PR adds the correct lower-bound pin for supported `typing-extensions` versions.