### PR TITLE
Fix Resource.anchors docstring: it returns anchors, not the identifier

### DIFF
--- a/referencing/_core.py
+++ b/referencing/_core.py
@@ -247,7 +247,7 @@ class Resource(Generic[D]):
 
     def anchors(self) -> Iterable[AnchorType[D]]:
         """
-        Retrieve this resource's (specification-specific) identifier.
+        Retrieve this resource's (specification-specific) anchors.
         """
         return self._specification.anchors_in(self.contents)
 


### PR DESCRIPTION
The docstring on `Resource.anchors` got copy-pasted from `Resource.id()` just above it: "Retrieve this resource's (specification-specific) identifier". The method returns anchors, not the identifier.