### PR TITLE
fix: resolve $dynamicRef for anonymous root schemas

### DIFF
--- a/referencing/jsonschema.py
+++ b/referencing/jsonschema.py
@@ -613,6 +613,13 @@ class DynamicAnchor:
                 continue
             if isinstance(anchor, DynamicAnchor):
                 last = anchor.resource
+        try:
+            anchor = resolver._registry.anchor("", self.name).value
+        except (exceptions.NoSuchAnchor, exceptions.NoSuchResource):
+            pass
+        else:
+            if isinstance(anchor, DynamicAnchor):
+                last = anchor.resource
         return _Resolved(
             contents=last.contents,
             resolver=resolver.in_subresource(last),

--- a/referencing/tests/test_jsonschema.py
+++ b/referencing/tests/test_jsonschema.py
@@ -304,7 +304,10 @@ def test_dynamic_ref_with_anonymous_root_schema():
     resolver = registry.resolver_with_root(anonymous)
     resolved = resolver.lookup("https://example.com/PaginatedTemplate")
     item_type = resolved.resolver.lookup("#itemType")
-    assert item_type.contents == {"$dynamicAnchor": "itemType", "type": "string"}
+    assert item_type.contents == {
+        "$dynamicAnchor": "itemType",
+        "type": "string",
+    }
 
 
 def test_lookup_trivial_recursive_ref():

--- a/referencing/tests/test_jsonschema.py
+++ b/referencing/tests/test_jsonschema.py
@@ -272,6 +272,41 @@ def test_multiple_lookup_dynamic_ref_to_nondynamic_ref():
     assert fourth.contents == two.contents
 
 
+def test_dynamic_ref_with_anonymous_root_schema():
+    template = referencing.jsonschema.DRAFT202012.create_resource(
+        {
+            "$id": "https://example.com/PaginatedTemplate",
+            "$defs": {
+                "itemType": {"$dynamicAnchor": "itemType", "not": {}},
+            },
+            "type": "object",
+            "required": ["items"],
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {"$dynamicRef": "#itemType"},
+                },
+            },
+        },
+    )
+    anonymous = referencing.jsonschema.DRAFT202012.create_resource(
+        {
+            "$defs": {
+                "itemType": {"$dynamicAnchor": "itemType", "type": "string"},
+            },
+            "$ref": "https://example.com/PaginatedTemplate",
+        },
+    )
+    registry = Registry().with_resource(
+        "https://example.com/PaginatedTemplate",
+        template,
+    )
+    resolver = registry.resolver_with_root(anonymous)
+    resolved = resolver.lookup("https://example.com/PaginatedTemplate")
+    item_type = resolved.resolver.lookup("#itemType")
+    assert item_type.contents == {"$dynamicAnchor": "itemType", "type": "string"}
+
+
 def test_lookup_trivial_recursive_ref():
     one = referencing.jsonschema.DRAFT201909.create_resource(
         {"$recursiveAnchor": True},


### PR DESCRIPTION
## Problem

When a root schema has no `$id` and uses `$ref` to pull in a template containing `$dynamicRef`, the `$dynamicRef` ignores any `$dynamicAnchor` overrides defined in the root schema's `$defs`. It falls back to the template's own `$dynamicAnchor` instead.

Filed from python-jsonschema/jsonschema#1497.

## Root Cause

`_evolve()` in `_core.py` uses a truthiness guard `if self._base_uri and ...` that treats `""` (the base URI for anonymous roots) as falsy. This prevents the anonymous root from being pushed onto the `_previous` stack, so it never appears in `dynamic_scope()`.

## Fix

Add an explicit lookup for the anonymous root (`""`) in `DynamicAnchor.resolve()` after iterating `dynamic_scope()`. This ensures `$dynamicAnchor` overrides on root schemas without `$id` are found.

## Test

Added `test_dynamic_ref_with_anonymous_root_schema` that reproduces the exact scenario from python-jsonschema/jsonschema#1497: an anonymous root with a `$dynamicAnchor` override that `$dynamicRef` should resolve to.

Fixes #366