### PR TITLE
Raise PointerToNowhere for non-integer array-index pointer segments

### DIFF
--- a/referencing/_core.py
+++ b/referencing/_core.py
@@ -264,7 +264,14 @@ class Resource(Generic[D]):
         segments: list[int | str] = []
         for segment in unquote(pointer[1:]).split("/"):
             if isinstance(contents, Sequence):
-                segment = int(segment)
+                try:
+                    segment = int(segment)
+                except ValueError as value_error:
+                    error = exceptions.PointerToNowhere(
+                        ref=pointer,
+                        resource=self,
+                    )
+                    raise error from value_error
             else:
                 segment = segment.replace("~1", "/").replace("~0", "~")
             try:

--- a/referencing/tests/test_core.py
+++ b/referencing/tests/test_core.py
@@ -762,6 +762,18 @@ class TestResolver:
             resource=resource,
         )
 
+    def test_lookup_non_integer_pointer_to_array_index(self):
+        resource = Resource.opaque([1, 2, 4, 8])
+        resolver = Registry({"http://example.com/1": resource}).resolver()
+        ref = "http://example.com/1#/foo"
+        with pytest.raises(exceptions.Unresolvable) as e:
+            resolver.lookup(ref)
+        assert e.value == exceptions.PointerToNowhere(
+            ref="/foo",
+            resource=resource,
+        )
+        assert str(e.value) == "'/foo' does not exist within [1, 2, 4, 8]"
+
     def test_lookup_pointer_to_empty_string(self):
         resolver = Registry().resolver_with_root(Resource.opaque({"": {}}))
         assert resolver.lookup("#/").contents == {}


### PR DESCRIPTION
A JSON Pointer segment that indexes into an array but is not a valid
integer -- e.g. `#/foo`, `#/-`, or `#/1x` -- previously caused the
`int(segment)` conversion in `Resource.pointer` to raise a raw
`ValueError`, which escaped `Resource.pointer` / `Resolver.lookup`.

The documented behavior (and the method's own docstring) is that a
pointer to a location that does not exist raises `PointerToNowhere`.
Per RFC 6901 section 4, an array reference token that is neither a valid
non-negative integer nor `-` does not resolve, so `PointerToNowhere` is
the correct, consistent result -- the same error already raised for an
out-of-range integer index such as `#/10`.

The `int()` conversion is now guarded so that a `ValueError` is turned
into `PointerToNowhere(ref=pointer, resource=self)`, chained from the
original error. A regression test covering a non-integer segment into an
array resource is added; it fails on `main` and passes with this change.

The full test suite (including the referencing-suite submodule) passes,
along with ruff and mypy.
