### PR TITLE
Exclude tests from wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.build.targets.wheel]
+exclude = ["referencing/tests/**"]
+
 [project]
 name = "referencing"
 description = "JSON Referencing + Python"


### PR DESCRIPTION
Fixes #402.

Configure Hatchling to exclude the bundled test package from wheel builds.
Source distributions continue to include the test suite.

Validation:

- `python -m pytest -q -p no:ruff referencing/tests` (`503 passed, 132 xfailed`, 100% coverage)
- `python -m build --wheel --sdist --no-isolation`
- Verified that the wheel omits `referencing/tests` while the sdist retains it
- `ruff check referencing noxfile.py`
- `git diff --check`

I used OpenAI Codex to help prepare this change; the patch and validation results were reviewed before submission.
